### PR TITLE
Fix isServiceFactory deprecation with Ember 1.13

### DIFF
--- a/addon/services/cart.js
+++ b/addon/services/cart.js
@@ -9,7 +9,7 @@ const {
 
 const get = Ember.get;
 
-export default ArrayProxy.extend({
+const CartService = ArrayProxy.extend({
   pushItem(item) {
     let cartItem;
 
@@ -76,3 +76,9 @@ export default ArrayProxy.extend({
     }
   }))
 });
+
+CartService.reopenClass({
+  isServiceFactory: true
+});
+
+export default CartService;


### PR DESCRIPTION
Since Ember 1.13, Ember expects that services either extend
`Ember.Service`, or they must set `isServiceFactory` to `true` at the
class level. Since the Cart service already extends `ArrayProxy`, this
commit reopens the Cart service class to set `isServiceFactory` to
`true`.

See https://github.com/emberjs/ember.js/pull/11261